### PR TITLE
feat: refactor route model

### DIFF
--- a/src/main/java/fr/iut/pathpilotapi/clients/ClientController.java
+++ b/src/main/java/fr/iut/pathpilotapi/clients/ClientController.java
@@ -5,9 +5,9 @@
 
 package fr.iut.pathpilotapi.clients;
 
+import fr.iut.pathpilotapi.clients.dto.ClientPagedModelAssembler;
 import fr.iut.pathpilotapi.clients.dto.ClientRequestModel;
 import fr.iut.pathpilotapi.clients.dto.ClientResponseModel;
-import fr.iut.pathpilotapi.clients.dto.ClientPagedModelAssembler;
 import fr.iut.pathpilotapi.clients.dto.ClientResponseModelAssembler;
 import fr.iut.pathpilotapi.salesman.Salesman;
 import fr.iut.pathpilotapi.security.SecurityUtils;

--- a/src/main/java/fr/iut/pathpilotapi/clients/ClientService.java
+++ b/src/main/java/fr/iut/pathpilotapi/clients/ClientService.java
@@ -5,9 +5,9 @@
 
 package fr.iut.pathpilotapi.clients;
 
-import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
 import fr.iut.pathpilotapi.clients.dto.ClientRequestModel;
 import fr.iut.pathpilotapi.clients.repository.ClientRepository;
+import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
 import fr.iut.pathpilotapi.salesman.Salesman;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;

--- a/src/main/java/fr/iut/pathpilotapi/itineraries/ItineraryService.java
+++ b/src/main/java/fr/iut/pathpilotapi/itineraries/ItineraryService.java
@@ -5,8 +5,8 @@
 
 package fr.iut.pathpilotapi.itineraries;
 
-import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
 import fr.iut.pathpilotapi.clients.ClientService;
+import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
 import fr.iut.pathpilotapi.itineraries.dto.ClientDTO;
 import fr.iut.pathpilotapi.itineraries.dto.ItineraryRequestModel;
 import fr.iut.pathpilotapi.salesman.Salesman;

--- a/src/main/java/fr/iut/pathpilotapi/routes/Route.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/Route.java
@@ -5,9 +5,8 @@
 
 package fr.iut.pathpilotapi.routes;
 
-import fr.iut.pathpilotapi.itineraries.dto.ClientDTO;
+import fr.iut.pathpilotapi.routes.dto.RouteClient;
 import jakarta.persistence.Id;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -17,7 +16,7 @@ import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.Date;
-import java.util.List;
+import java.util.LinkedList;
 import java.util.Objects;
 
 /**
@@ -26,10 +25,8 @@ import java.util.Objects;
  * <ul>
  *     <li>Salesman ID</li>
  *     <li>Home position of the salesman</li>
- *     <li>Clients schedule</li>
  *     <li>Start date</li>
- *     <li>Visited clients</li>
- *     <li>Expected clients</li>
+ *     <li>clients</li>
  *     <li>Current position of the salesman</li>
  *     <li>Is the route finished</li>
  * </ul>
@@ -51,11 +48,9 @@ public class Route {
     @GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE)
     private GeoJsonPoint salesman_home;
 
-    private List<@NotNull ClientDTO> expected_clients;
-
     private Date startDate;
 
-    private List<@NotNull ClientDTO> visited_clients;
+    private LinkedList<RouteClient> clients;
 
     @GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE)
     private GeoJsonPoint salesman_current_position;
@@ -68,15 +63,14 @@ public class Route {
         return Objects.equals(id, route.id) &&
                 Objects.equals(salesmanId, route.salesmanId) &&
                 Objects.equals(salesman_home, route.salesman_home) &&
-                Objects.equals(expected_clients, route.expected_clients) &&
                 Objects.equals(startDate, route.startDate) &&
-                Objects.equals(visited_clients, route.visited_clients) &&
+                Objects.equals(clients, route.clients) &&
                 Objects.equals(salesman_current_position, route.salesman_current_position);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, salesmanId, salesman_home, expected_clients, startDate, visited_clients, salesman_current_position);
+        return Objects.hash(id, salesmanId, salesman_home, clients, startDate, salesman_current_position);
     }
 
     @Override
@@ -85,9 +79,8 @@ public class Route {
                 "id=" + id +
                 ", salesman=" + salesmanId +
                 ", salesman_home=" + salesman_home +
-                ", clients_schedule=" + expected_clients +
                 ", startDate=" + startDate +
-                ", clients_visited=" + visited_clients +
+                ", clients=" + clients +
                 ", salesManCurrentPosition=" + salesman_current_position +
                 '}';
     }

--- a/src/main/java/fr/iut/pathpilotapi/routes/RouteController.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/RouteController.java
@@ -133,5 +133,5 @@ public class RouteController {
         return ResponseEntity.ok(new DeleteStatus(true));
     }
 
-    private record DeleteStatus (boolean isDelete) {}
+    private record DeleteStatus (boolean isDeleted) {}
 }

--- a/src/main/java/fr/iut/pathpilotapi/routes/RouteService.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/RouteService.java
@@ -8,6 +8,9 @@ package fr.iut.pathpilotapi.routes;
 import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
 import fr.iut.pathpilotapi.itineraries.Itinerary;
 import fr.iut.pathpilotapi.itineraries.ItineraryService;
+import fr.iut.pathpilotapi.itineraries.dto.ClientDTO;
+import fr.iut.pathpilotapi.routes.dto.ClientState;
+import fr.iut.pathpilotapi.routes.dto.RouteClient;
 import fr.iut.pathpilotapi.salesman.Salesman;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,7 +19,7 @@ import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
-import java.util.List;
+import java.util.LinkedList;
 
 /**
  * Service to manipulate routes
@@ -56,10 +59,13 @@ public class RouteService {
         //Retrieve Itinerary data
         route.setSalesmanId(salesman.getId());
         route.setSalesman_home(new GeoJsonPoint(salesman.getLongHomeAddress(), salesman.getLatHomeAddress()));
-        route.setExpected_clients(itinerary.getClients_schedule());
+        LinkedList<RouteClient> routeClients = new LinkedList<>();
+        for (ClientDTO client: itinerary.getClients_schedule()) {
+            routeClients.add(new RouteClient(client, ClientState.EXPECTED));
+        }
+        route.setClients(routeClients);
 
         route.setSalesman_current_position(route.getSalesman_home());
-        route.setVisited_clients(List.of());
         route.setStartDate(new Date());
 
         return routeRepository.save(route);

--- a/src/main/java/fr/iut/pathpilotapi/routes/dto/ClientState.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/dto/ClientState.java
@@ -1,0 +1,15 @@
+/*
+ * ClientState.java                                 07 Feb 2025
+ * IUT de Rodez, no author rights
+ */
+
+package fr.iut.pathpilotapi.routes.dto;
+
+/**
+ * Enum representing the state of a client in a route
+ */
+public enum ClientState {
+    VISITED,
+    EXPECTED,
+    SKIPPED
+}

--- a/src/main/java/fr/iut/pathpilotapi/routes/dto/RouteClient.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/dto/RouteClient.java
@@ -1,0 +1,21 @@
+/*
+ * RouteClient.java                                 07 Feb 2025
+ * IUT de Rodez, no author rights
+ */
+
+package fr.iut.pathpilotapi.routes.dto;
+
+import fr.iut.pathpilotapi.itineraries.dto.ClientDTO;
+
+/**
+ * Class representing a client in a route
+ * <h3>Mandatory fields</h3>
+ * <ul>
+ *     <li>Client</li>
+ *     <li>State</li>
+ * </ul>
+ * @see ClientDTO
+ * @see ClientState
+ */
+public record RouteClient(ClientDTO client , ClientState state) {
+}

--- a/src/main/java/fr/iut/pathpilotapi/routes/dto/RouteRequestModel.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/dto/RouteRequestModel.java
@@ -8,6 +8,6 @@ package fr.iut.pathpilotapi.routes.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-@Schema(description = "Route  entity representing a route in order to create it")
+@Schema(description = "Route entity representing a route in order to create it")
 public record RouteRequestModel(@NotNull String itineraryId) {
 }

--- a/src/main/java/fr/iut/pathpilotapi/routes/dto/RouteResponseModel.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/dto/RouteResponseModel.java
@@ -5,7 +5,6 @@
 
 package fr.iut.pathpilotapi.routes.dto;
 
-import fr.iut.pathpilotapi.itineraries.dto.ClientDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -16,7 +15,7 @@ import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.hateoas.RepresentationModel;
 
 import java.util.Date;
-import java.util.List;
+import java.util.LinkedList;
 
 import static fr.iut.pathpilotapi.Constants.MAX_CLIENTS;
 
@@ -35,15 +34,11 @@ public class RouteResponseModel extends RepresentationModel<RouteResponseModel> 
     @NotEmpty
     @NotNull
     @Size(max = MAX_CLIENTS)
-    @Schema(description = "List of the clients to visit in the route")
-    private List<@NotNull ClientDTO> expected_clients;
+    @Schema(description = "List of the clients in the route")
+    private LinkedList<@NotNull RouteClient> clients;
 
     @Schema(description = "Start date of the route", example = "2024-12-06T00:00:00.000Z")
     private Date startDate;
-
-    @Size(max = MAX_CLIENTS)
-    @Schema(description = "List of the clients already visited")
-    private List<@NotNull ClientDTO> visited_clients;
 
     @Schema(description = "Current position of the salesman", example = "{type: 'Point', coordinates: [48.8566, 2.3522]}")
     private GeoJsonPoint salesman_current_position;

--- a/src/test/java/fr/iut/pathpilotapi/clients/ClientServiceTest.java
+++ b/src/test/java/fr/iut/pathpilotapi/clients/ClientServiceTest.java
@@ -5,9 +5,9 @@
 
 package fr.iut.pathpilotapi.clients;
 
-import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
 import fr.iut.pathpilotapi.clients.dto.ClientRequestModel;
 import fr.iut.pathpilotapi.clients.repository.ClientRepository;
+import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
 import fr.iut.pathpilotapi.salesman.Salesman;
 import fr.iut.pathpilotapi.test.IntegrationTestUtils;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/fr/iut/pathpilotapi/itineraries/ItineraryServiceIntegrationTest.java
+++ b/src/test/java/fr/iut/pathpilotapi/itineraries/ItineraryServiceIntegrationTest.java
@@ -1,8 +1,8 @@
 package fr.iut.pathpilotapi.itineraries;
 
-import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
 import fr.iut.pathpilotapi.clients.Client;
 import fr.iut.pathpilotapi.clients.repository.ClientRepository;
+import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
 import fr.iut.pathpilotapi.itineraries.dto.ItineraryRequestModel;
 import fr.iut.pathpilotapi.salesman.Salesman;
 import fr.iut.pathpilotapi.salesman.SalesmanRepository;

--- a/src/test/java/fr/iut/pathpilotapi/routes/RouteControllerIntegrationTest.java
+++ b/src/test/java/fr/iut/pathpilotapi/routes/RouteControllerIntegrationTest.java
@@ -75,7 +75,7 @@ class RouteControllerIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.routeResponseModelList", hasSize(1)))
                 .andExpect(jsonPath("$._embedded.routeResponseModelList[0].id").value(route.getId()))
-                .andExpect(jsonPath("$._embedded.routeResponseModelList[0].expected_clients[0].id").value(clientCreated.getId()));
+                .andExpect(jsonPath("$._embedded.routeResponseModelList[0].clients[0].client.id").value(clientCreated.getId()));
     }
 
     @Test
@@ -109,7 +109,7 @@ class RouteControllerIntegrationTest {
                 // Then we should get the route back
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(route.getId()))
-                .andExpect(jsonPath("$.expected_clients[0].id").value(clientCreated.getId()));
+                .andExpect(jsonPath("$.clients[0].client.id").value(clientCreated.getId()));
     }
 
 
@@ -138,7 +138,7 @@ class RouteControllerIntegrationTest {
                 // Then we should get the created route back
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").isNotEmpty())
-                .andExpect(jsonPath("$.expected_clients[0].id").value(clientCreated.getId()));
+                .andExpect(jsonPath("$.clients[0].client.id").value(clientCreated.getId()));
     }
 
     @Test

--- a/src/test/java/fr/iut/pathpilotapi/routes/RouteServiceIntegrationTest.java
+++ b/src/test/java/fr/iut/pathpilotapi/routes/RouteServiceIntegrationTest.java
@@ -64,7 +64,9 @@ class RouteServiceIntegrationTest {
         // Then the route is created and saved in the database
         assertNotNull(routeCreated);
         assertEquals(itinerary.getSalesman_home(), routeCreated.getSalesman_home());
-        assertEquals(itinerary.getClients_schedule(), routeCreated.getExpected_clients());
+        routeCreated.getClients().forEach(routeClient ->
+                assertTrue(itinerary.getClients_schedule().contains(routeClient.client()))
+        );
         assertEquals(itinerary, itineraryService.findByIdAndConnectedSalesman(itinerary.getId(), salesman));
     }
 

--- a/src/test/java/fr/iut/pathpilotapi/routes/RouteTest.java
+++ b/src/test/java/fr/iut/pathpilotapi/routes/RouteTest.java
@@ -1,11 +1,13 @@
 package fr.iut.pathpilotapi.routes;
 
 import fr.iut.pathpilotapi.itineraries.dto.ClientDTO;
+import fr.iut.pathpilotapi.routes.dto.ClientState;
+import fr.iut.pathpilotapi.routes.dto.RouteClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 
-import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedList;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -24,9 +26,8 @@ class RouteTest {
         route1.setId("1");
         route1.setSalesman_home(new GeoJsonPoint(0.0, 0.0));
         route1.setSalesmanId(1);
-        route1.setExpected_clients(new ArrayList<>());
+        route1.setClients(new LinkedList<>());
         route1.setSalesman_current_position(new GeoJsonPoint(0.0, 0.0));
-        route1.setVisited_clients(new ArrayList<>());
         route1.setStartDate(new Date());
 
         // Test if a route is equals to herself but with basic data
@@ -40,19 +41,18 @@ class RouteTest {
         route2.setId(route1.getId());
         route2.setSalesman_home(route1.getSalesman_home());
         route2.setSalesmanId(route1.getSalesmanId());
-        route2.setExpected_clients(route1.getExpected_clients());
+        route2.setClients(route1.getClients());
         route2.setSalesman_current_position(route1.getSalesman_current_position());
-        route2.setVisited_clients(route1.getVisited_clients());
         route2.setStartDate(route1.getStartDate());
 
         // Test if two route with the same data are equal but isn't the same instance
         assertEquals(route1, route2);
         assertNotSame(route1, route2);
 
-        route1.getExpected_clients().add(new ClientDTO());
-        route1.getExpected_clients().add(new ClientDTO());
-        route2.getExpected_clients().add(new ClientDTO());
-        route2.getExpected_clients().add(new ClientDTO());
+        route1.getClients().add(new RouteClient(new ClientDTO(), ClientState.EXPECTED));
+        route1.getClients().add(new RouteClient(new ClientDTO(), ClientState.EXPECTED));
+        route2.getClients().add(new RouteClient(new ClientDTO(), ClientState.EXPECTED));
+        route2.getClients().add(new RouteClient(new ClientDTO(), ClientState.EXPECTED));
 
         assertEquals(route1, route2);
         assertNotSame(route1, route2);

--- a/src/test/java/fr/iut/pathpilotapi/test/IntegrationTestUtils.java
+++ b/src/test/java/fr/iut/pathpilotapi/test/IntegrationTestUtils.java
@@ -16,10 +16,13 @@ import fr.iut.pathpilotapi.itineraries.Itinerary;
 import fr.iut.pathpilotapi.itineraries.dto.ClientDTO;
 import fr.iut.pathpilotapi.itineraries.dto.ItineraryRequestModel;
 import fr.iut.pathpilotapi.routes.Route;
+import fr.iut.pathpilotapi.routes.dto.ClientState;
+import fr.iut.pathpilotapi.routes.dto.RouteClient;
 import fr.iut.pathpilotapi.salesman.Salesman;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
@@ -205,7 +208,11 @@ public class IntegrationTestUtils {
         route.setId(UUID.randomUUID().toString());
         route.setSalesmanId(salesman.getId());
         route.setSalesman_home(position);
-        route.setExpected_clients(clients);
+        LinkedList<RouteClient> routeClients = new LinkedList<>();
+        for (ClientDTO client: clients) {
+            routeClients.add(new RouteClient(client, ClientState.EXPECTED));
+        }
+        route.setClients(routeClients);
 
         return route;
     }


### PR DESCRIPTION
Close #31 
This pull request includes several changes focused on refactoring the `Route` class and related components to use a new `RouteClient` structure and `ClientState` enum. Additionally, it includes some minor import reordering for consistency across various files.

### Refactoring `Route` class and related components:

* [`src/main/java/fr/iut/pathpilotapi/routes/Route.java`](diffhunk://#diff-7fb8c2f7d06ed482d44e3d8e77359f51d3e17310d717aca110ec6fe1ae857489L8-L10): Replaced `expected_clients` and `visited_clients` with a single `clients` field of type `LinkedList<RouteClient>`. Updated related methods and documentation to reflect this change. [[1]](diffhunk://#diff-7fb8c2f7d06ed482d44e3d8e77359f51d3e17310d717aca110ec6fe1ae857489L8-L10) [[2]](diffhunk://#diff-7fb8c2f7d06ed482d44e3d8e77359f51d3e17310d717aca110ec6fe1ae857489L20-R19) [[3]](diffhunk://#diff-7fb8c2f7d06ed482d44e3d8e77359f51d3e17310d717aca110ec6fe1ae857489L29-R29) [[4]](diffhunk://#diff-7fb8c2f7d06ed482d44e3d8e77359f51d3e17310d717aca110ec6fe1ae857489L54-R53) [[5]](diffhunk://#diff-7fb8c2f7d06ed482d44e3d8e77359f51d3e17310d717aca110ec6fe1ae857489L71-R73) [[6]](diffhunk://#diff-7fb8c2f7d06ed482d44e3d8e77359f51d3e17310d717aca110ec6fe1ae857489L88-R83)
* [`src/main/java/fr/iut/pathpilotapi/routes/RouteService.java`](diffhunk://#diff-de6c8c97422670bebaa18e361b5a6f4e552c8c51e860b1e525951db671f224b1R11-R13): Updated the `createRoute` method to populate the `clients` field with `RouteClient` objects, setting their state to `EXPECTED`. [[1]](diffhunk://#diff-de6c8c97422670bebaa18e361b5a6f4e552c8c51e860b1e525951db671f224b1R11-R13) [[2]](diffhunk://#diff-de6c8c97422670bebaa18e361b5a6f4e552c8c51e860b1e525951db671f224b1L19-R22) [[3]](diffhunk://#diff-de6c8c97422670bebaa18e361b5a6f4e552c8c51e860b1e525951db671f224b1L59-L62)
* [`src/main/java/fr/iut/pathpilotapi/routes/dto/ClientState.java`](diffhunk://#diff-673a47d9ca6f389548f0d6224398128277acffda627ffd4909848a4e02cacd81R1-R15): Added a new `ClientState` enum to represent the state of a client in a route.
* [`src/main/java/fr/iut/pathpilotapi/routes/dto/RouteClient.java`](diffhunk://#diff-3416faa53072e57a4ac8f4f341ccfa42cd9aea2752f4abeec41cbe581dc19794R1-R21): Added a new `RouteClient` record to encapsulate a client and its state within a route.
* [`src/main/java/fr/iut/pathpilotapi/routes/dto/RouteResponseModel.java`](diffhunk://#diff-faeba657991f9678060956667111da9b67c94dcd850570d774355b959c4ef15bL8): Updated to use `LinkedList<RouteClient>` for the `clients` field instead of separate lists for `expected_clients` and `visited_clients`. [[1]](diffhunk://#diff-faeba657991f9678060956667111da9b67c94dcd850570d774355b959c4ef15bL8) [[2]](diffhunk://#diff-faeba657991f9678060956667111da9b67c94dcd850570d774355b959c4ef15bL19-R18) [[3]](diffhunk://#diff-faeba657991f9678060956667111da9b67c94dcd850570d774355b959c4ef15bL38-L47)

### Minor import reordering:

* Reordered imports in several files for consistency:
  * `src/main/java/fr/iut/pathpilotapi/clients/ClientController.java`
  * `src/main/java/fr/iut/pathpilotapi/clients/ClientService.java`
  * `src/main/java/fr/iut/pathpilotapi/itineraries/ItineraryService.java`
  * `src/test/java/fr/iut/pathpilotapi/clients/ClientServiceTest.java`
  * `src/test/java/fr/iut/pathpilotapi/itineraries/ItineraryServiceIntegrationTest.java`

### Tests and other updates:

* Updated test files to reflect changes in the `Route` class and related components:
  * `src/test/java/fr/iut/pathpilotapi/routes/RouteControllerIntegrationTest.java` [[1]](diffhunk://#diff-6fb505ec14b4bddf12c5048507c5d903a7664e9f849834d6351b5a7d67fb57deL78-R78) [[2]](diffhunk://#diff-6fb505ec14b4bddf12c5048507c5d903a7664e9f849834d6351b5a7d67fb57deL112-R112) [[3]](diffhunk://#diff-6fb505ec14b4bddf12c5048507c5d903a7664e9f849834d6351b5a7d67fb57deL141-R141)
  * `src/test/java/fr/iut/pathpilotapi/routes/RouteServiceIntegrationTest.java`
  * `src/test/java/fr/iut/pathpilotapi/routes/RouteTest.java` [[1]](diffhunk://#diff-7d8fc162b0a55edb89d5239fec63181343caac463397a2fd9688d78ba6a1dab2R4-R10) [[2]](diffhunk://#diff-7d8fc162b0a55edb89d5239fec63181343caac463397a2fd9688d78ba6a1dab2L27-L29) [[3]](diffhunk://#diff-7d8fc162b0a55edb89d5239fec63181343caac463397a2fd9688d78ba6a1dab2L43-R55)
  * `src/test/java/fr/iut/pathpilotapi/test/IntegrationTestUtils.java` [[1]](diffhunk://#diff-c315bd30295c004f503eaa8fb931e90d790a7f667026fbb9672939c069f9c9d7R19-R25) [[2]](diffhunk://#diff-c315bd30295c004f503eaa8fb931e90d790a7f667026fbb9672939c069f9c9d7L208-R215)

* Corrected a typo in `RouteController.java` by renaming `isDelete` to `isDeleted` in the `DeleteStatus` record.