### PR TITLE
feat: add pause route functionality

### DIFF
--- a/src/main/java/fr/iut/pathpilotapi/routes/RouteController.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/RouteController.java
@@ -107,7 +107,7 @@ public class RouteController {
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "The route has been updated with the state to FINISHED"
+                            description = "The route has been updated with the state to STOPPED"
                     ),
                     @ApiResponse(responseCode = "400", description = "Client error"),
                     @ApiResponse(responseCode = "500", description = "Server error")
@@ -115,7 +115,7 @@ public class RouteController {
     )
     @PatchMapping("/{id}/stop")
     public ResponseEntity<EntityModel<Status>> stopRoute(
-            @Parameter(name = "id", description = "The route id to start the route")
+            @Parameter(name = "id", description = "The route id to stop the route")
             @PathVariable String id
     ) {
         Salesman salesman = SecurityUtils.getCurrentSalesman();
@@ -129,6 +129,39 @@ public class RouteController {
         );
         return ResponseEntity.ok(statusModel);
     }
+
+    @Operation(
+            summary = "Pause a route",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "The route has been updated with the state to PAUSED"
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Client error"),
+                    @ApiResponse(responseCode = "500", description = "Server error")
+            }
+    )
+    @PatchMapping("/{id}/pause")
+    public ResponseEntity<EntityModel<Status>> pauseRoute(
+            @Parameter(name = "id", description = "The route id to pause the route")
+            @PathVariable String id
+    ) {
+        Salesman salesman = SecurityUtils.getCurrentSalesman();
+        routeService.pauseRoute(id, salesman);
+
+        EntityModel<Status> statusModel = EntityModel.of(new Status(true));
+        statusModel.add(
+                linkTo(
+                        methodOn(RouteController.class).pauseRoute(id)
+                ).withSelfRel()
+                ).add(
+                linkTo(
+                        methodOn(RouteController.class).stopRoute(id)
+                ).withSelfRel()
+                );
+        return ResponseEntity.ok(statusModel);
+    }
+
 
     @Operation(
             summary = "Get a route",
@@ -231,6 +264,8 @@ public class RouteController {
 
         return ResponseEntity.ok(new Status(true));
     }
+
+
 
     private record Status (boolean state) {}
 }

--- a/src/main/java/fr/iut/pathpilotapi/routes/RouteService.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/RouteService.java
@@ -103,21 +103,43 @@ public class RouteService {
     }
 
     /**
+     * Pauses a Route in the database.
+     *
+     * @param routeId  the ID of the route to pause the route
+     * @param salesman who pause the route
+     */
+    public void pauseRoute(String routeId, Salesman salesman) {
+        setRouteState(routeId, RouteState.PAUSED, salesman);
+    }
+
+    /**
      * Completely stops a Route in the database.
      *
      * @param routeId  the ID of the route to stop the route
      * @param salesman who stop the route
      */
     public void stopRoute(String routeId, Salesman salesman) {
-        Route route = findByIdAndConnectedSalesman(routeId, salesman);
+        setRouteState(routeId, RouteState.STOPPED, salesman);
+    }
 
-        route.setState(RouteState.STOPPED);
+    /**
+     * Set the route state to one of the {@link RouteState} values
+     *
+     * @param routeId  the ID of the route to set the state
+     * @param state the state to set
+     * @param salesman who set the state
+     */
+    public void setRouteState(String routeId, RouteState state, Salesman salesman) {
+        Route route = findByIdAndConnectedSalesman(routeId, salesman);
+        route.setState(state);
         routeRepository.save(route);
 
         mongoTemplate.updateFirst(query(where("id").is(routeId)),
-                new Update().set("state", RouteState.STOPPED),
+                new Update().set("state", state),
                 Route.class);
     }
+
+
 
     /**
      * Find a route by its ID and the connected salesman


### PR DESCRIPTION
- Implemented a new endpoint to pause routes.
- Updated existing stop route logic to reflect state changes.
- Added service method for pausing routes and refactored state setting.
- Enhanced API documentation for clarity on route states.
- Created integration tests for the new pause feature, including edge cases.