### PR TITLE
changed update position response to return a full Client

### DIFF
--- a/src/test/java/fr/iut/pathpilotapi/routes/RouteServiceIntegrationTest.java
+++ b/src/test/java/fr/iut/pathpilotapi/routes/RouteServiceIntegrationTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
@@ -437,7 +438,6 @@ class RouteServiceIntegrationTest {
         // Then an exception should be thrown with the message "Route not found with ID: invalidRouteId"
         assertEquals("Route not found with ID: " + routeId, exception.getMessage());
     }
-
     @Test
     void testFindNearbyClients() {
         // Given a route, a salesman, a point, and a distance
@@ -455,12 +455,12 @@ class RouteServiceIntegrationTest {
         mongoTemplate.save(client);
 
         // When finding nearby clients
-        List<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(), new Distance(distanceInKm));
+        Page<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(), new Distance(distanceInKm));
 
         // Then the result should contain the expected clients
         assertNotNull(nearbyClients);
-        assertEquals(1, nearbyClients.size());
-        assertEquals(client, nearbyClients.get(0));
+        assertEquals(1, nearbyClients.getTotalElements());
+        assertEquals(client, nearbyClients.getContent().get(0));
     }
 
     @Test
@@ -484,12 +484,12 @@ class RouteServiceIntegrationTest {
         mongoTemplate.save(client2);
 
         // When finding nearby clients
-        List<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(client2), new Distance(distanceInKm));
+        Page<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(client2), new Distance(distanceInKm));
 
         // Then the result should contain the expected clients
         assertNotNull(nearbyClients);
-        assertEquals(1, nearbyClients.size());
-        assertEquals(client1, nearbyClients.get(0));
+        assertEquals(1, nearbyClients.getTotalElements());
+        assertEquals(client1, nearbyClients.getContent().get(0));
     }
 
     @Test
@@ -503,7 +503,7 @@ class RouteServiceIntegrationTest {
         double distanceInKm = 1.0;
 
         // When finding nearby clients
-        List<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(), new Distance(distanceInKm));
+        Page<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(), new Distance(distanceInKm));
 
         // Then the result should be an empty list
         assertNotNull(nearbyClients);
@@ -526,7 +526,7 @@ class RouteServiceIntegrationTest {
         mongoTemplate.save(client);
 
         // When finding nearby clients
-        List<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(client), new Distance(distanceInKm));
+        Page<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(client), new Distance(distanceInKm));
 
         // Then the result should be an empty list
         assertNotNull(nearbyClients);
@@ -549,7 +549,7 @@ class RouteServiceIntegrationTest {
         mongoTemplate.save(client);
 
         // When finding nearby clients
-        List<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(), new Distance(distanceInKm));
+        Page<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(), new Distance(distanceInKm));
 
         // Then the result should be an empty list
         assertNotNull(nearbyClients);

--- a/src/test/java/fr/iut/pathpilotapi/routes/RouteServiceTest.java
+++ b/src/test/java/fr/iut/pathpilotapi/routes/RouteServiceTest.java
@@ -416,12 +416,12 @@ class RouteServiceTest {
         when(mongoClientRepository.findByLocationNear(point, new Distance(distanceInKm))).thenReturn(List.of(client));
 
         // When finding nearby clients
-        List<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(), new Distance(distanceInKm));
+        Page<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(), new Distance(distanceInKm));
 
         // Then the result should contain the expected clients
         assertNotNull(nearbyClients);
-        assertEquals(1, nearbyClients.size());
-        assertEquals(client, nearbyClients.get(0));
+        assertEquals(1, nearbyClients.getTotalElements());
+        assertEquals(client, nearbyClients.getContent().get(0));
     }
 
     @Test
@@ -437,7 +437,7 @@ class RouteServiceTest {
         when(mongoClientRepository.findByLocationNear(point, new Distance(distanceInKm))).thenReturn(Collections.emptyList());
 
         // When finding nearby clients
-        List<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(), new Distance(distanceInKm));
+        Page<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(), new Distance(distanceInKm));
 
         // Then the result should be an empty list
         assertNotNull(nearbyClients);
@@ -465,14 +465,13 @@ class RouteServiceTest {
         when(mongoClientRepository.findByLocationNear(point, new Distance(distanceInKm))).thenReturn(List.of(client));
 
         // When finding nearby clients
-        List<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(clientToAvoid), new Distance(distanceInKm));
+        Page<MongoClient> nearbyClients = routeService.findNearbyClients(route.getId(), salesman, point, List.of(clientToAvoid), new Distance(distanceInKm));
 
         // Then the result should contain the expected clients
         assertNotNull(nearbyClients);
-        assertEquals(1, nearbyClients.size());
-        assertEquals(client, nearbyClients.get(0));
+        assertEquals(1, nearbyClients.getTotalElements());
+        assertEquals(client, nearbyClients.getContent().get(0));
     }
-
 
     @Test
     void testStartRoute() {


### PR DESCRIPTION
This pull request introduces several changes to the `RouteController` and `RouteService` classes, focusing on updating how nearby clients are handled and returned. The key changes include switching from lists to paginated responses and updating the corresponding tests.

### Key Changes:

**RouteController Updates:**
* Added new imports and fields for `ClientService` and `ClientPagedModelAssembler` to handle client-related operations and pagination. [[1]](diffhunk://#diff-aa783a53931d0c632315ede98d6a7347cfec76a2ff7d47028161ca8e58464d64R9-R12) [[2]](diffhunk://#diff-aa783a53931d0c632315ede98d6a7347cfec76a2ff7d47028161ca8e58464d64R59-R62)
* Modified the `updateSalesmanPosition` method to return a paginated model of `ClientResponseModel` instead of a collection model.

**RouteService Updates:**
* Changed the `findNearbyClients` method to return a `Page<MongoClient>` instead of a list, ensuring paginated results. [[1]](diffhunk://#diff-de6c8c97422670bebaa18e361b5a6f4e552c8c51e860b1e525951db671f224b1L273-R278) [[2]](diffhunk://#diff-de6c8c97422670bebaa18e361b5a6f4e552c8c51e860b1e525951db671f224b1L282-R292)

**Test Updates:**
* Updated integration and unit tests to handle the new paginated response format in `findNearbyClients`. [[1]](diffhunk://#diff-e4a2e168c25581b77a5e9c7badb403287c9998a3619e1c3c1c10684856f87ae1L458-R463) [[2]](diffhunk://#diff-e4a2e168c25581b77a5e9c7badb403287c9998a3619e1c3c1c10684856f87ae1L487-R492) [[3]](diffhunk://#diff-e4a2e168c25581b77a5e9c7badb403287c9998a3619e1c3c1c10684856f87ae1L506-R506) [[4]](diffhunk://#diff-e4a2e168c25581b77a5e9c7badb403287c9998a3619e1c3c1c10684856f87ae1L529-R529) [[5]](diffhunk://#diff-e4a2e168c25581b77a5e9c7badb403287c9998a3619e1c3c1c10684856f87ae1L552-R552) [[6]](diffhunk://#diff-f2fc790f13a3af921189ccc10e2c21de2e1fd871472964d57f6b9f1c03a6ad5bL419-R424) [[7]](diffhunk://#diff-f2fc790f13a3af921189ccc10e2c21de2e1fd871472964d57f6b9f1c03a6ad5bL440-R440) [[8]](diffhunk://#diff-f2fc790f13a3af921189ccc10e2c21de2e1fd871472964d57f6b9f1c03a6ad5bL468-L476)