### PR TITLE
change RouteResponseModel to match Route model

### DIFF
--- a/src/main/java/fr/iut/pathpilotapi/routes/RouteController.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/RouteController.java
@@ -354,7 +354,8 @@ public class RouteController {
                     return clientService.findByIdAndConnectedSalesman(client.getId(), salesman);
                 })
                 .toList();
-        Page<Client> clientsPage = new PageImpl<>(clients, PageRequest.of(0, clients.size()), clients.size());
+        int pageSize = Math.max(clients.size(), 1); // Ensure page size is at least 1
+        Page<Client> clientsPage = new PageImpl<>(clients, PageRequest.of(0, pageSize), clients.size());
 
         PagedModel<ClientResponseModel> pagedModel = clientPagedModelAssembler.toModel(clientsPage);
 

--- a/src/main/java/fr/iut/pathpilotapi/routes/dto/RouteResponseModel.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/dto/RouteResponseModel.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.mongodb.core.geo.GeoJsonLineString;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.hateoas.RepresentationModel;
 
@@ -42,7 +43,7 @@ public class RouteResponseModel extends RepresentationModel<RouteResponseModel> 
     private Date startDate;
 
     @Schema(description = "Current position of the salesman", example = "{type: 'Point', coordinates: [48.8566, 2.3522]}")
-    private GeoJsonPoint salesman_current_position;
+    private GeoJsonLineString salesmanPositions;
 
     @Schema(description = "Route state : NOT_STARTED or IN_PROGRESS or PAUSED or FINISHED", example = "false")
     private RouteState state;


### PR DESCRIPTION
This pull request includes updates to ensure proper handling of page size in the `RouteController` and changes to the `RouteResponseModel` to use a different data type for the salesman's positions.

Changes to `RouteController`:

* Ensured the page size is at least 1 when creating a `Page<Client>` object to avoid potential issues with an empty page. (`src/main/java/fr/iut/pathpilotapi/routes/RouteController.java`)

Changes to `RouteResponseModel`:

* Imported `GeoJsonLineString` to handle the salesman's positions as a line string instead of a point. (`src/main/java/fr/iut/pathpilotapi/routes/dto/RouteResponseModel.java`)
* Changed the `salesman_current_position` field to `salesmanPositions` and updated its type from `GeoJsonPoint` to `GeoJsonLineString` to better represent the route. (`src/main/java/fr/iut/pathpilotapi/routes/dto/RouteResponseModel.java`)