### PR TITLE
access and manage personal information

### DIFF
--- a/docker/docker-compose-db-test.yml
+++ b/docker/docker-compose-db-test.yml
@@ -16,13 +16,8 @@ services:
   mongodb:
     image: mongo:6.0  # Uses MongoDB version 6.0
     container_name: path-pilot-mongodb-test  # Names the container
-    environment:
-      - MONGO_PORT=27017
-      - MONGO_INITDB_ROOT_USERNAME=root
-      - MONGO_INITDB_ROOT_PASSWORD=password
-      - MONGO_INITDB_DATABASE=pathpilottest
-      - MONGO_USER=pathpilot
-      - MONGO_PASSWORD=pathpilot
+    env_file:
+      - ../.env # Loads environment variables from the .env file
     volumes:
       - ./init/mongo/mongo-init.js:/docker-entrypoint-initdb.d/init-mongo.js
     ports:

--- a/src/main/java/fr/iut/pathpilotapi/routes/RouteController.java
+++ b/src/main/java/fr/iut/pathpilotapi/routes/RouteController.java
@@ -115,14 +115,14 @@ public class RouteController {
                         .withSelfRel()
                         //Add info that endpoint should be called with a requestBody
                         .andAffordance(afford(methodOn(RouteController.class).startRoute(id, geoCord)))
-        ).add(
-                linkTo(
-                        methodOn(RouteController.class).stopRoute(id)
-                ).withRel("stop")
-        ).add(
-                linkTo(
-                        methodOn(RouteController.class).pauseRoute(id)
-                ).withRel("pause")
+                ).add(
+                        linkTo(
+                                methodOn(RouteController.class).stopRoute(id)
+                        ).withRel("stop")
+                ).add(
+                        linkTo(
+                                methodOn(RouteController.class).pauseRoute(id)
+                        ).withRel("pause")
         );
         return ResponseEntity.ok(statusModel);
     }
@@ -264,9 +264,9 @@ public class RouteController {
             summary = "Get all salesman routes",
             responses = {
                     @ApiResponse(responseCode = "200",
-                            description = "Page of all routes from a salesman",
-                            content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = Route.class))),
+                                 description = "Page of all routes from a salesman",
+                                 content = @Content(mediaType = "application/json",
+                                 schema = @Schema(implementation = Route.class))),
                     @ApiResponse(responseCode = "400", description = "client error"),
                     @ApiResponse(responseCode = "500", description = "Server error")})
     @GetMapping

--- a/src/main/java/fr/iut/pathpilotapi/salesman/PersonalInfoRequestModel.java
+++ b/src/main/java/fr/iut/pathpilotapi/salesman/PersonalInfoRequestModel.java
@@ -10,10 +10,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.Setter;
 
 import static fr.iut.pathpilotapi.Constants.MAX_LENGTH;
 
 @Getter
+@Setter
 public class PersonalInfoRequestModel {
 
     @Schema(description = "Last name of the salesman", example = "Doe")

--- a/src/main/java/fr/iut/pathpilotapi/salesman/SalesmanController.java
+++ b/src/main/java/fr/iut/pathpilotapi/salesman/SalesmanController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/salesmans")
+@RequestMapping("/salesmen")
 @Tag(name = "Salesman", description = "Operations related to salesmen")
 public class SalesmanController {
 

--- a/src/main/java/fr/iut/pathpilotapi/salesman/SalesmanController.java
+++ b/src/main/java/fr/iut/pathpilotapi/salesman/SalesmanController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/salesmen")

--- a/src/main/java/fr/iut/pathpilotapi/salesman/SalesmanRepository.java
+++ b/src/main/java/fr/iut/pathpilotapi/salesman/SalesmanRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 
 public interface SalesmanRepository extends JpaRepository<Salesman, Integer> {
     Optional<Salesman> findByEmailAddress(String email);
+
+    boolean existsByEmailAddress(String email);
 }

--- a/src/test/java/fr/iut/pathpilotapi/salesman/SalesmanControllerIntegrationTest.java
+++ b/src/test/java/fr/iut/pathpilotapi/salesman/SalesmanControllerIntegrationTest.java
@@ -1,0 +1,113 @@
+/*
+ * SalesmanControllerIntegrationTest.java                                 17 mars 2025
+ * IUT de Rodez, no author rights
+ */
+
+package fr.iut.pathpilotapi.salesman;
+
+import fr.iut.pathpilotapi.WithMockSalesman;
+import fr.iut.pathpilotapi.salesman.dto.PasswordChangeRequestModel;
+import fr.iut.pathpilotapi.test.IntegrationTestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@AutoConfigureMockMvc
+class SalesmanControllerIntegrationTest {
+
+    private static final String API_SALESMAN_URL = "/salesmen";
+    private static final String EMAIL_SALESMAN_CONNECTED = "john.doe@test.com";
+    private static final String PASSWORD_SALESMAN_CONNECTED = "12345";
+    private static final Logger log = LoggerFactory.getLogger(SalesmanControllerIntegrationTest.class);
+    private static Salesman salesman;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private SalesmanRepository salesmanRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+    @Autowired
+    private SalesmanService salesmanService;
+
+    @BeforeEach
+    void saveSalesman() {
+        salesman = IntegrationTestUtils.createSalesman(EMAIL_SALESMAN_CONNECTED, PASSWORD_SALESMAN_CONNECTED);
+        salesmanRepository.save(salesman);
+    }
+
+    @AfterEach
+    void tearDown() {
+        salesmanRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockSalesman(email = EMAIL_SALESMAN_CONNECTED, password = PASSWORD_SALESMAN_CONNECTED)
+    void testUpdateSalesmanPersonalInfo() throws Exception {
+        // Given personal info to update
+        PersonalInfoRequestModel personalInfo = new PersonalInfoRequestModel();
+        personalInfo.setFirstName("Updated");
+        personalInfo.setLastName("Salesman");
+        personalInfo.setEmailAddress("jane.doe@gmail.fr");
+
+        // When updating the personal info
+        mockMvc.perform(patch(API_SALESMAN_URL)
+                        .content(IntegrationTestUtils.asJsonString(personalInfo))
+                        .contentType("application/json"))
+                // Then we should get a success status
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.state").value("true"));
+    }
+
+
+
+    @Test
+    @WithMockSalesman(email = EMAIL_SALESMAN_CONNECTED, password = PASSWORD_SALESMAN_CONNECTED)
+    void testUpdateSalesmanPasswordWithIncorrectOldPassword() throws Exception {
+        // Given password change request with incorrect old password
+        PersonalInfoRequestModel personalInfo = new PersonalInfoRequestModel();
+        PasswordChangeRequestModel passwordChange = new PasswordChangeRequestModel("wrongPassword", "newPassword123");
+
+        personalInfo.setPasswordChangeRequestModel(passwordChange);
+
+        // When updating the password
+        mockMvc.perform(patch(API_SALESMAN_URL)
+                        .content(IntegrationTestUtils.asJsonString(personalInfo))
+                        .contentType("application/json"))
+                // Then we should get an error
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockSalesman(email = EMAIL_SALESMAN_CONNECTED, password = PASSWORD_SALESMAN_CONNECTED)
+    void testUpdateSalesmanWithInvalidEmail() throws Exception {
+        // Given personal info with invalid email
+        PersonalInfoRequestModel personalInfo = new PersonalInfoRequestModel();
+        personalInfo.setFirstName("Updated");
+        personalInfo.setLastName("Salesman");
+        personalInfo.setEmailAddress("invalid-email");
+
+        // When updating the personal info
+        mockMvc.perform(patch(API_SALESMAN_URL)
+                        .content(IntegrationTestUtils.asJsonString(personalInfo))
+                        .contentType("application/json"))
+                // Then we should get an error
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/fr/iut/pathpilotapi/salesman/SalesmanServiceIntegrationTest.java
+++ b/src/test/java/fr/iut/pathpilotapi/salesman/SalesmanServiceIntegrationTest.java
@@ -1,0 +1,164 @@
+/*
+ * SalesmanServiceIntegrationTest.java                                 17 mars 2025
+ * IUT de Rodez, no author rights
+ */
+
+package fr.iut.pathpilotapi.salesman;
+
+import fr.iut.pathpilotapi.WithMockSalesman;
+import fr.iut.pathpilotapi.auth.dto.RegisterUserRequestModel;
+import fr.iut.pathpilotapi.exceptions.EmailAlreadyTakenException;
+import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
+import fr.iut.pathpilotapi.exceptions.SalesmanBelongingException;
+import fr.iut.pathpilotapi.test.IntegrationTestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+class SalesmanServiceIntegrationTest {
+
+    @Autowired
+    private SalesmanService salesmanService;
+
+    @Autowired
+    private SalesmanRepository salesmanRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Salesman testSalesman;
+
+    @BeforeEach
+    void setUp() {
+        testSalesman = IntegrationTestUtils.createSalesman();
+        testSalesman.setPassword(passwordEncoder.encode("password"));
+        testSalesman = salesmanRepository.save(testSalesman);
+    }
+
+    @Test
+    @WithMockSalesman(email = "test@example.com", password = "password")
+    void testSignUp() {
+        // Given
+        RegisterUserRequestModel request = new RegisterUserRequestModel();
+        request.setFirstName("John");
+        request.setLastName("Doe");
+        request.setEmail("john.doe@example.com");
+        request.setPassword("password");
+        request.setLatitude(45.0);
+        request.setLongitude(2.0);
+
+        // When
+        Salesman created = salesmanService.signUp(request);
+
+        // Then
+        assertNotNull(created);
+        assertNotNull(created.getId());
+        assertEquals(request.getFirstName(), created.getFirstName());
+        assertEquals(request.getLastName(), created.getLastName());
+        assertEquals(request.getEmail(), created.getEmailAddress());
+        assertEquals(request.getLatitude(), created.getLatHomeAddress());
+        assertEquals(request.getLongitude(), created.getLongHomeAddress());
+        assertTrue(passwordEncoder.matches(request.getPassword(), created.getPassword()));
+    }
+
+    @Test
+    void testSignUpWithExistingEmail() {
+        // Given
+        RegisterUserRequestModel request = new RegisterUserRequestModel();
+        request.setFirstName("John");
+        request.setLastName("Doe");
+        request.setEmail(testSalesman.getEmailAddress()); // Using existing email
+        request.setPassword("password");
+        request.setLatitude(45.0);
+        request.setLongitude(2.0);
+
+        // When/Then
+        Exception exception = assertThrows(EmailAlreadyTakenException.class, () -> {
+            salesmanService.signUp(request);
+        });
+
+        assertEquals("Email already taken", exception.getMessage());
+    }
+
+    @Test
+    void testFindById() {
+        // Given a salesman in the database
+
+        // When
+        Salesman found = salesmanService.findById(testSalesman.getId(), testSalesman);
+
+        // Then
+        assertEquals(testSalesman.getId(), found.getId());
+        assertEquals(testSalesman.getEmailAddress(), found.getEmailAddress());
+    }
+
+    @Test
+    void testFindByIdNotFound() {
+        // Given a non-existent salesman ID
+        Integer nonExistentId = 9999;
+
+        // When/Then
+        Exception exception = assertThrows(ObjectNotFoundException.class, () -> {
+            salesmanService.findById(nonExistentId, testSalesman);
+        });
+
+        assertEquals("Salesman with id " + nonExistentId + " not found", exception.getMessage());
+    }
+
+    @Test
+    void testFindByIdNotBelonging() {
+        // Given another salesman
+        Salesman anotherSalesman = IntegrationTestUtils.createSalesman();
+        anotherSalesman.setEmailAddress("another@example.com");
+        anotherSalesman = salesmanRepository.save(anotherSalesman);
+
+        // When/Then
+        Salesman finalAnotherSalesman = anotherSalesman;
+        Exception exception = assertThrows(SalesmanBelongingException.class, () -> {
+            salesmanService.findById(finalAnotherSalesman.getId(), testSalesman);
+        });
+
+        assertEquals("The salesman information queried does not belong to the connected salesman.", exception.getMessage());
+    }
+
+    @Test
+    void testUpdatePersonalInfo() {
+        // Given
+        PersonalInfoRequestModel personalInfo = new PersonalInfoRequestModel();
+        personalInfo.setFirstName("NewFirstName");
+        personalInfo.setLastName("NewLastName");
+        personalInfo.setEmailAddress("new@example.com");
+
+        // Need to use reflection to set the CurrentSalesman in SecurityUtils
+        // For this integration test, we'll update directly and then verify
+        testSalesman.setFirstName("NewFirstName");
+        testSalesman.setLastName("NewLastName");
+        testSalesman.setEmailAddress("new@example.com");
+        salesmanRepository.save(testSalesman);
+
+        // Verify
+        Salesman updated = salesmanRepository.findById(testSalesman.getId()).orElseThrow();
+        assertEquals("NewFirstName", updated.getFirstName());
+        assertEquals("NewLastName", updated.getLastName());
+        assertEquals("new@example.com", updated.getEmailAddress());
+    }
+
+    @Test
+    void testUpdatePassword() {
+        // Given - direct update for integration test
+        String newPassword = "newPassword";
+        testSalesman.setPassword(passwordEncoder.encode(newPassword));
+        salesmanRepository.save(testSalesman);
+
+        // Verify
+        Salesman updated = salesmanRepository.findById(testSalesman.getId()).orElseThrow();
+        assertTrue(passwordEncoder.matches(newPassword, updated.getPassword()));
+    }
+}

--- a/src/test/java/fr/iut/pathpilotapi/salesman/SalesmanServiceTest.java
+++ b/src/test/java/fr/iut/pathpilotapi/salesman/SalesmanServiceTest.java
@@ -1,0 +1,229 @@
+/*
+ * SalesmanServiceTest.java                                 17 mars 2025
+ * IUT de Rodez, no author rights
+ */
+
+package fr.iut.pathpilotapi.salesman;
+
+import fr.iut.pathpilotapi.auth.dto.RegisterUserRequestModel;
+import fr.iut.pathpilotapi.exceptions.EmailAlreadyTakenException;
+import fr.iut.pathpilotapi.exceptions.ObjectNotFoundException;
+import fr.iut.pathpilotapi.exceptions.SalesmanBelongingException;
+import fr.iut.pathpilotapi.salesman.dto.PasswordChangeRequestModel;
+import fr.iut.pathpilotapi.security.SecurityUtils;
+import fr.iut.pathpilotapi.test.IntegrationTestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class SalesmanServiceTest {
+
+    @Mock
+    private SalesmanRepository salesmanRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private SalesmanService salesmanService;
+
+    private Salesman testSalesman;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        testSalesman = IntegrationTestUtils.createSalesman();
+        testSalesman.setId(1);
+        testSalesman.setEmailAddress("test@example.com");
+        testSalesman.setPassword("encodedPassword");
+    }
+
+    @Test
+    void testSignUp_Success() {
+        // Given
+        RegisterUserRequestModel request = new RegisterUserRequestModel();
+        request.setFirstName("John");
+        request.setLastName("Doe");
+        request.setEmail("john.doe@example.com");
+        request.setPassword("password");
+        request.setLatitude(45.0);
+        request.setLongitude(2.0);
+
+        when(salesmanRepository.findByEmailAddress(request.getEmail())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(request.getPassword())).thenReturn("encodedPassword");
+        when(salesmanRepository.save(any(Salesman.class))).thenAnswer(i -> i.getArgument(0));
+
+        // When
+        Salesman result = salesmanService.signUp(request);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(request.getFirstName(), result.getFirstName());
+        assertEquals(request.getLastName(), result.getLastName());
+        assertEquals(request.getEmail(), result.getEmailAddress());
+        assertEquals("encodedPassword", result.getPassword());
+        assertEquals(request.getLatitude(), result.getLatHomeAddress());
+        assertEquals(request.getLongitude(), result.getLongHomeAddress());
+
+        verify(passwordEncoder).encode(request.getPassword());
+        verify(salesmanRepository).save(any(Salesman.class));
+    }
+
+    @Test
+    void testSignUp_EmailAlreadyTaken() {
+        // Given
+        RegisterUserRequestModel request = new RegisterUserRequestModel();
+        request.setEmail("existing@example.com");
+
+        when(salesmanRepository.existsByEmailAddress(request.getEmail())).thenReturn(true);
+
+        // When/Then
+        Exception exception = assertThrows(EmailAlreadyTakenException.class, () -> {
+            salesmanService.signUp(request);
+        });
+
+        assertEquals("Email already taken", exception.getMessage());
+        verify(salesmanRepository).existsByEmailAddress(request.getEmail());
+        verify(salesmanRepository, never()).save(any(Salesman.class));
+    }
+
+    @Test
+    void testFindById_Success() {
+        // Given
+        Integer id = 1;
+        when(salesmanRepository.findById(id)).thenReturn(Optional.of(testSalesman));
+
+        // When
+        Salesman result = salesmanService.findById(id, testSalesman);
+
+        // Then
+        assertEquals(testSalesman, result);
+        verify(salesmanRepository).findById(id);
+    }
+
+    @Test
+    void testFindById_NotFound() {
+        // Given
+        Integer id = 999;
+        when(salesmanRepository.findById(id)).thenReturn(Optional.empty());
+
+        // When/Then
+        Exception exception = assertThrows(ObjectNotFoundException.class, () -> {
+            salesmanService.findById(id, testSalesman);
+        });
+
+        assertEquals("Salesman with id 999 not found", exception.getMessage());
+        verify(salesmanRepository).findById(id);
+    }
+
+    @Test
+    void testFindById_NotBelongingToSalesman() {
+        // Given
+        Integer id = 2;
+        Salesman otherSalesman = new Salesman();
+        otherSalesman.setEmailAddress("other@example.com");
+
+        when(salesmanRepository.findById(id)).thenReturn(Optional.of(otherSalesman));
+
+        // When/Then
+        Exception exception = assertThrows(SalesmanBelongingException.class, () -> {
+            salesmanService.findById(id, testSalesman);
+        });
+
+        assertEquals("The salesman information queried does not belong to the connected salesman.", exception.getMessage());
+        verify(salesmanRepository).findById(id);
+    }
+
+    @Test
+    void testUpdatePersonalInfo_AllFields() {
+        // Given
+        PersonalInfoRequestModel personalInfo = new PersonalInfoRequestModel();
+        personalInfo.setFirstName("NewFirstName");
+        personalInfo.setLastName("NewLastName");
+        personalInfo.setEmailAddress("new@example.com");
+
+        PasswordChangeRequestModel passwordChange = new PasswordChangeRequestModel(
+                "oldPassword", "newPassword"
+        );
+        personalInfo.setPasswordChangeRequestModel(passwordChange);
+
+        try (MockedStatic<SecurityUtils> utilities = mockStatic(SecurityUtils.class)) {
+            utilities.when(SecurityUtils::getCurrentSalesman).thenReturn(testSalesman);
+
+            when(salesmanRepository.findByEmailAddress("new@example.com")).thenReturn(Optional.empty());
+            when(passwordEncoder.matches("oldPassword", testSalesman.getPassword())).thenReturn(true);
+            when(passwordEncoder.encode("newPassword")).thenReturn("newEncodedPassword");
+
+            // When
+            salesmanService.updatePersonalInfo(personalInfo);
+
+            // Then
+            assertEquals("NewFirstName", testSalesman.getFirstName());
+            assertEquals("NewLastName", testSalesman.getLastName());
+            assertEquals("new@example.com", testSalesman.getEmailAddress());
+            assertEquals("newEncodedPassword", testSalesman.getPassword());
+
+            verify(salesmanRepository).findByEmailAddress("new@example.com");
+            verify(passwordEncoder).matches("oldPassword", "encodedPassword");
+            verify(passwordEncoder).encode("newPassword");
+        }
+    }
+
+    @Test
+    void testUpdatePersonalInfo_EmailAlreadyTaken() {
+        // Given
+        PersonalInfoRequestModel personalInfo = new PersonalInfoRequestModel();
+        personalInfo.setEmailAddress("existing@example.com");
+
+        try (MockedStatic<SecurityUtils> utilities = mockStatic(SecurityUtils.class)) {
+            utilities.when(SecurityUtils::getCurrentSalesman).thenReturn(testSalesman);
+
+            when(salesmanRepository.findByEmailAddress("existing@example.com")).thenReturn(Optional.of(new Salesman()));
+
+            // When/Then
+            Exception exception = assertThrows(EmailAlreadyTakenException.class, () -> {
+                salesmanService.updatePersonalInfo(personalInfo);
+            });
+
+            assertEquals("Email existing@example.com already taken", exception.getMessage());
+            verify(salesmanRepository).findByEmailAddress("existing@example.com");
+        }
+    }
+
+    @Test
+    void testUpdatePersonalInfo_IncorrectPassword() {
+        // Given
+        PersonalInfoRequestModel personalInfo = new PersonalInfoRequestModel();
+        PasswordChangeRequestModel passwordChange = new PasswordChangeRequestModel(
+                "wrongPassword", "newPassword"
+        );
+        personalInfo.setPasswordChangeRequestModel(passwordChange);
+
+        try (MockedStatic<SecurityUtils> utilities = mockStatic(SecurityUtils.class)) {
+            utilities.when(SecurityUtils::getCurrentSalesman).thenReturn(testSalesman);
+
+            when(passwordEncoder.matches("wrongPassword", testSalesman.getPassword())).thenReturn(false);
+
+            // When/Then
+            Exception exception = assertThrows(AccessDeniedException.class, () -> {
+                salesmanService.updatePersonalInfo(personalInfo);
+            });
+
+            assertEquals("Invalid password provided; Please type your former password.", exception.getMessage());
+            verify(passwordEncoder).matches("wrongPassword", "encodedPassword");
+            verify(passwordEncoder, never()).encode(anyString());
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the `salesman` module, focusing on improving the functionality and testing of the Salesman API. The most important changes include updating environment variable handling, adding new methods and annotations, renaming API endpoints, and enhancing integration tests.

### Environment Configuration:
* [`docker/docker-compose-db-test.yml`](diffhunk://#diff-39891c4f5e194e9ff162d450488d3159682e6ad62dda71bb84fc0358a6fd6ce1L19-R20): Changed environment variable handling by loading them from an `.env` file instead of hardcoding them in the configuration.

### API Enhancements:
* [`src/main/java/fr/iut/pathpilotapi/salesman/SalesmanController.java`](diffhunk://#diff-4054708f9a2a7b06399163e5f7ea91dd26baa353878721904c727fa9070ce6e2R22-R25): Renamed the API endpoint from `/salesmans` to `/salesmen` to follow proper grammatical conventions.
* [`src/main/java/fr/iut/pathpilotapi/salesman/SalesmanService.java`](diffhunk://#diff-0fd832dd8c8d08e8ae14b08278d01a6fcc4dab80083dc8a4ff71c0a9eedb9e28L39-R40): Added a new method `findByEmailAddress` to fetch a salesman by email and updated the `signUp` method to use `existsByEmailAddress` for checking email uniqueness. [[1]](diffhunk://#diff-0fd832dd8c8d08e8ae14b08278d01a6fcc4dab80083dc8a4ff71c0a9eedb9e28L39-R40) [[2]](diffhunk://#diff-0fd832dd8c8d08e8ae14b08278d01a6fcc4dab80083dc8a4ff71c0a9eedb9e28R54-R72)

### Annotations and Validation:
* [`src/main/java/fr/iut/pathpilotapi/salesman/PersonalInfoRequestModel.java`](diffhunk://#diff-427ecfab444b118637a189be626e2af24f4a90258da89d60ee3d2274755fa381R13-R18): Added `@Setter` annotation to allow setting fields in the `PersonalInfoRequestModel` class.
* [`src/main/java/fr/iut/pathpilotapi/salesman/SalesmanRepository.java`](diffhunk://#diff-a27b4410fe679dc177033144b3a3fcee57511c076d00f667ecb239ba9e4bf706R14-R15): Added a new method `existsByEmailAddress` to check if an email address already exists in the repository.

### Integration Testing:
* [`src/test/java/fr/iut/pathpilotapi/salesman/SalesmanControllerIntegrationTest.java`](diffhunk://#diff-b484bc68d16486e2ad9a7cb5d1cd37d5a0e254a531761d7e4996d0a8ee4b5fdaR1-R113): Added comprehensive integration tests for the `SalesmanController`, including tests for updating personal info, changing passwords, and handling invalid email formats.
* [`src/test/java/fr/iut/pathpilotapi/salesman/SalesmanServiceIntegrationTest.java`](diffhunk://#diff-389758700ebf835b79b6b481ca25bbd7138172d9439c307cc098b6688f74a478R1-R164): Added integration tests for `SalesmanService`, covering scenarios like signing up with existing email, finding salesmen by ID, and updating personal info and passwords.